### PR TITLE
Fix failing Docker run test

### DIFF
--- a/test/elixir_experience/models/docker_test.exs
+++ b/test/elixir_experience/models/docker_test.exs
@@ -7,7 +7,10 @@ defmodule ElixirExperience.DockerTest do
     it "runs a bad code and captures output" do
       {output, exit_code} = Docker.run("garbage")
       assert exit_code == 1
-      assert output == "** (CompileError) nofile:1: undefined function garbage/0\n    (elixir) lib/code.ex:140: Code.eval_string/3"
+      assert output == """
+      ** (CompileError) nofile:1: undefined function garbage/0
+          (elixir) lib/code.ex:131: Code.eval_string/3\
+      """
     end
 
     it "runs code and captures output" do


### PR DESCRIPTION
This test was failing due to the line number being wrong.

```
  1) test run runs a bad code and captures output (ElixirExperience.DockerTest)
     test/elixir_experience/models/docker_test.exs:7
     Assertion with == failed
     code: output == "** (CompileError) nofile:1: undefined function garbage/0\n    (elixir) lib/code.ex:131: Code.eval_string/3\n"
     lhs:  "** (CompileError) nofile:1: undefined function garbage/0\n    (elixir) lib/code.ex:131: Code.eval_string/3"
     rhs:  "** (CompileError) nofile:1: undefined function garbage/0\n    (elixir) lib/code.ex:131: Code.eval_string/3\n"
     stacktrace:
       test/elixir_experience/models/docker_test.exs:10
```

The line number thing seems a little brittle. Should use a regex to check the message, ignoring the number?